### PR TITLE
fix: 修复配额验证中的带宽检查逻辑

### DIFF
--- a/server/service/resources/quota.go
+++ b/server/service/resources/quota.go
@@ -167,11 +167,10 @@ func (s *QuotaService) validateInTransaction(tx *gorm.DB, req ResourceRequest) (
 	}
 
 	// 5. 检查带宽限制
-	levelBandwidthLimit := s.getLevelBandwidthLimit(user.Level)
-	if requestedResources.Bandwidth > levelBandwidthLimit {
+	if requestedResources.Bandwidth > maxResources.Bandwidth {
 		result.Allowed = false
 		result.Reason = fmt.Sprintf("带宽超出等级限制：需要 %dMbps，等级 %d 最大允许 %dMbps",
-			requestedResources.Bandwidth, user.Level, levelBandwidthLimit)
+			requestedResources.Bandwidth, user.Level, maxResources.Bandwidth)
 		return result, nil
 	}
 


### PR DESCRIPTION
- 将带宽限制检查从使用 getLevelBandwidthLimit 函数改为直接使用 maxResources.Bandwidth
- 简化了带宽验证逻辑，提高代码可维护性