### PR TITLE
feat(docker): 配置MySQL持久化存储和字符集设置

### DIFF
--- a/deploy/my.cnf
+++ b/deploy/my.cnf
@@ -1,0 +1,11 @@
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_general_ci
+explicit_defaults_for_timestamp=true
+lower_case_table_names=1
+
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
     container_name: api
     volumes:
       - ./data/app/:/app/storage
+      - ./server/config.yaml:/app/config.yaml:rw
     networks:
       - default
 
@@ -29,9 +30,14 @@ services:
         MYSQL_ALLOW_EMPTY_PASSWORD:  "yes"
         MYSQL_DATABASE: oneclickvirt
     volumes:
-      - ./data/mysql:/var/lib/mysql
+      - mysql_data:/var/lib/mysql
+      - ./deploy/my.cnf:/etc/mysql/conf.d/custom.cnf
     networks:
       - default
 
+volumes:
+  mysql_data:
+
 networks:
   default:
+    driver: bridge


### PR DESCRIPTION
- 添加了MySQL数据卷用于持久化存储
- 挂载自定义MySQL配置文件以支持utf8mb4字符集
- 更新docker-compose网络驱动为bridge模式- 映射服务器配置文件到API容器
- 添加mysql_data命名卷以提高数据安全性