### PR TITLE
fix: 修复在纯IPv4模式下错误创建vmbr2网桥的bug

### DIFF
--- a/server/provider/proxmox/api.go
+++ b/server/provider/proxmox/api.go
@@ -975,23 +975,13 @@ func (p *ProxmoxProvider) apiCreateVM(ctx context.Context, vmid int, config prov
 	cpuFormatted := convertCPUFormat(config.CPU)
 	memoryFormatted := convertMemoryFormat(config.Memory)
 
-	// 获取IPv6配置信息
-	ipv6Info, err := p.getIPv6Info(ctx)
-	if err != nil {
-		global.APP_LOG.Warn("获取IPv6信息失败，使用默认网络配置", zap.Error(err))
-		ipv6Info = &IPv6Info{HasAppendedAddresses: false}
-	}
+	// 解析网络配置，判断是否需要IPv6
+	networkConfig := p.parseNetworkConfigFromInstanceConfig(config)
+	hasIPv6 := networkConfig.NetworkType == "nat_ipv4_ipv6" ||
+		networkConfig.NetworkType == "dedicated_ipv4_ipv6" ||
+		networkConfig.NetworkType == "ipv6_only"
 
-	var net1Bridge string
-	if ipv6Info.HasAppendedAddresses {
-		net1Bridge = "vmbr1"
-	} else {
-		net1Bridge = "vmbr2"
-	}
-
-	// 通过API创建虚拟机
-	url := fmt.Sprintf("https://%s:8006/api2/json/nodes/%s/qemu", p.config.Host, p.node)
-
+	// 构建payload基础配置
 	payload := map[string]interface{}{
 		"vmid":    vmid,
 		"name":    config.Name,
@@ -1002,11 +992,42 @@ func (p *ProxmoxProvider) apiCreateVM(ctx context.Context, vmid int, config prov
 		"sockets": "1",
 		"cpu":     cpuType,
 		"net0":    "virtio,bridge=vmbr1,firewall=0",
-		"net1":    fmt.Sprintf("virtio,bridge=%s,firewall=0", net1Bridge),
 		"ostype":  "l26",
 		"kvm":     fmt.Sprintf("%d", kvmFlag),
 		"memory":  memoryFormatted,
 	}
+
+	// 只有在需要IPv6时才配置net1接口和vmbr2
+	if hasIPv6 {
+		// 获取IPv6配置信息
+		ipv6Info, err := p.getIPv6Info(ctx)
+		if err != nil {
+			global.APP_LOG.Warn("获取IPv6信息失败，使用默认网络配置", zap.Error(err))
+			ipv6Info = &IPv6Info{HasAppendedAddresses: false}
+		}
+
+		var net1Bridge string
+		if ipv6Info.HasAppendedAddresses {
+			net1Bridge = "vmbr1"
+		} else {
+			net1Bridge = "vmbr2"
+		}
+
+		// 添加IPv6网络接口
+		payload["net1"] = fmt.Sprintf("virtio,bridge=%s,firewall=0", net1Bridge)
+
+		global.APP_LOG.Info("配置VM的IPv6网络接口",
+			zap.Int("vmid", vmid),
+			zap.String("bridge", net1Bridge),
+			zap.Bool("hasAppendedAddresses", ipv6Info.HasAppendedAddresses))
+	} else {
+		global.APP_LOG.Info("网络类型不包含IPv6，跳过net1接口配置",
+			zap.Int("vmid", vmid),
+			zap.String("networkType", networkConfig.NetworkType))
+	}
+
+	// 通过API创建虚拟机
+	url := fmt.Sprintf("https://%s:8006/api2/json/nodes/%s/qemu", p.config.Host, p.node)
 
 	jsonData, err := json.Marshal(payload)
 	if err != nil {

--- a/server/provider/proxmox/ssh.go
+++ b/server/provider/proxmox/ssh.go
@@ -1249,26 +1249,50 @@ func (p *ProxmoxProvider) createVM(ctx context.Context, vmid int, config provide
 		storage = "local" // 默认存储
 	}
 
-	// 获取IPv6配置信息来决定网络桥接
-	ipv6Info, err := p.getIPv6Info(ctx)
-	if err != nil {
-		global.APP_LOG.Warn("获取IPv6信息失败，使用默认网络配置", zap.Error(err))
-		ipv6Info = &IPv6Info{HasAppendedAddresses: false}
-	}
+	// 解析网络配置，判断是否需要IPv6
+	networkConfig := p.parseNetworkConfigFromInstanceConfig(config)
+	hasIPv6 := networkConfig.NetworkType == "nat_ipv4_ipv6" ||
+		networkConfig.NetworkType == "dedicated_ipv4_ipv6" ||
+		networkConfig.NetworkType == "ipv6_only"
 
-	// 根据IPv6配置选择第二个网络桥接
-	var net1Bridge string
-	if ipv6Info.HasAppendedAddresses {
-		net1Bridge = "vmbr1"
-	} else {
-		net1Bridge = "vmbr2"
-	}
-
-	// 创建虚拟机，包含IPv6网络接口
+	// 构建基础创建命令（只包含net0）
 	createCmd := fmt.Sprintf(
-		"qm create %d --agent 1 --scsihw virtio-scsi-single --serial0 socket --cores %s --sockets 1 --cpu %s --net0 virtio,bridge=vmbr1,firewall=0 --net1 virtio,bridge=%s,firewall=0 --ostype l26 %s",
-		vmid, cpuFormatted, cpuType, net1Bridge, kvmFlag,
+		"qm create %d --agent 1 --scsihw virtio-scsi-single --serial0 socket --cores %s --sockets 1 --cpu %s --net0 virtio,bridge=vmbr1,firewall=0 --ostype l26 %s",
+		vmid, cpuFormatted, cpuType, kvmFlag,
 	)
+
+	// 只有在需要IPv6时才添加net1接口
+	if hasIPv6 {
+		// 获取IPv6配置信息来决定网络桥接
+		ipv6Info, err := p.getIPv6Info(ctx)
+		if err != nil {
+			global.APP_LOG.Warn("获取IPv6信息失败，使用默认网络配置", zap.Error(err))
+			ipv6Info = &IPv6Info{HasAppendedAddresses: false}
+		}
+
+		// 根据IPv6配置选择第二个网络桥接
+		var net1Bridge string
+		if ipv6Info.HasAppendedAddresses {
+			net1Bridge = "vmbr1"
+		} else {
+			net1Bridge = "vmbr2"
+		}
+
+		// 添加IPv6网络接口到创建命令
+		createCmd = fmt.Sprintf(
+			"qm create %d --agent 1 --scsihw virtio-scsi-single --serial0 socket --cores %s --sockets 1 --cpu %s --net0 virtio,bridge=vmbr1,firewall=0 --net1 virtio,bridge=%s,firewall=0 --ostype l26 %s",
+			vmid, cpuFormatted, cpuType, net1Bridge, kvmFlag,
+		)
+
+		global.APP_LOG.Info("配置VM的IPv6网络接口",
+			zap.Int("vmid", vmid),
+			zap.String("bridge", net1Bridge),
+			zap.Bool("hasAppendedAddresses", ipv6Info.HasAppendedAddresses))
+	} else {
+		global.APP_LOG.Info("网络类型不包含IPv6，跳过net1接口配置",
+			zap.Int("vmid", vmid),
+			zap.String("networkType", networkConfig.NetworkType))
+	}
 
 	_, err = p.sshClient.Execute(createCmd)
 	if err != nil {


### PR DESCRIPTION
问题描述：
- 当受控端是PVE且只有IPv4地址时
- 面板端在节点管理中仅设置NAT IPv4模式
- 代码会错误地向受控端发送建立vmbr2的bridge命令
- vmbr2应该仅用于IPv6，不应该在纯IPv4模式下使用

修复方案：
1. 在创建VM前先解析网络配置类型
2. 只有在网络类型包含IPv6时（nat_ipv4_ipv6, dedicated_ipv4_ipv6, ipv6_only）才：
   - 获取IPv6配置信息
   - 根据IPv6信息决定使用vmbr1还是vmbr2
   - 创建net1网络接口
3. 纯IPv4模式（nat_ipv4, dedicated_ipv4）下不创建net1接口，不使用vmbr2

修改文件：
- server/provider/proxmox/api.go: 修复apiCreateVM函数
- server/provider/proxmox/ssh.go: 修复createVM函数